### PR TITLE
Replaced some GetRegistryLength references to GetRegistryLengthAllowU…

### DIFF
--- a/TrustKit/parse_configuration.m
+++ b/TrustKit/parse_configuration.m
@@ -69,7 +69,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
     for (NSString *domainName in trustKitArguments[kTSKPinnedDomains])
     {
         // Sanity checks on the domain name
-        if (GetRegistryLength([domainName UTF8String]) == 0)
+        if (GetRegistryLengthAllowUnknownRegistries([domainName UTF8String]) == 0)
         {
             [NSException raise:@"TrustKit configuration invalid"
                         format:@"TrustKit was initialized with an invalid domain %@", domainName];
@@ -117,7 +117,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
             {
                 // Prevent pinning on *.com
                 // Ran into this issue with *.appspot.com which is part of the public suffix list
-                if (GetRegistryLength([domainName UTF8String]) == [domainName length])
+                if (GetRegistryLengthAllowUnknownRegistries([domainName UTF8String]) == [domainName length])
                 {
                     [NSException raise:@"TrustKit configuration invalid"
                                 format:@"TrustKit was initialized with includeSubdomains for a domain suffix %@", domainName];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replaced some GetRegistryLength references to GetRegistryLengthAllowUnknownRegistries

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
https://trello.com/c/kqWE7EDK/48-ssl-pinning-plugin-check-if-requires-changes-for-ios12

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly